### PR TITLE
Create `ECSSystemNode`

### DIFF
--- a/project/ecs/system_node.gd
+++ b/project/ecs/system_node.gd
@@ -1,5 +1,5 @@
-extends RefCounted
-class_name ECSSystem
+extends Node
+class_name ECSSystemNode
 
 var _name: String
 var _world: WeakRef
@@ -19,15 +19,36 @@ func multi_view(names: Array[String], filter: Callable = Callable()) -> Array:
 func group(name: String) -> Array:
 	return world().group(name)
 	
+func get_remote_sender_id() -> int:
+	return multiplayer.get_remote_sender_id() if is_inside_tree() else -1
+	
+func get_rpc_unique_id() -> int:
+	return multiplayer.get_unique_id() if is_inside_tree() else -1
+	
+func is_server() -> bool:
+	return multiplayer.is_server() if is_inside_tree() else false
+	
+func is_peer_connected() -> bool:
+	var peer: MultiplayerPeer = peer()
+	return peer.get_connection_status() == MultiplayerPeer.CONNECTION_CONNECTED if peer else false
+	
+func peer() -> MultiplayerPeer:
+	return multiplayer.multiplayer_peer if is_inside_tree() else null
+	
+func set_peer(peer: MultiplayerPeer):
+	if is_inside_tree():
+		multiplayer.multiplayer_peer = peer
+	
 func on_enter(w: ECSWorld):
 	if w.debug_print:
-		print("system <%s:%s> on_enter." % [world().name(), _name])
+		print("system_node <%s:%s> on_enter." % [world().name(), _name])
 	_on_enter(w)
 	
 func on_exit(w: ECSWorld):
 	if w.debug_print:
-		print("system <%s:%s> on_exit." % [world().name(), _name])
+		print("system_node <%s:%s> on_exit." % [world().name(), _name])
 	_on_exit(w)
+	queue_free()
 	
 func notify(event_name: String, value = null):
 	world().notify(event_name, value)
@@ -49,6 +70,10 @@ func _on_exit(w: ECSWorld):
 # ==============================================================================
 # private function
 	
+func _init(parent: Node = null):
+	if parent:
+		parent.add_child(self)
+	
 func _set_name(n: String):
 	_name = n
 	
@@ -56,5 +81,5 @@ func _set_world(w: ECSWorld):
 	_world = weakref(w)
 	
 func _to_string() -> String:
-	return "system:%s" % _name
+	return "system_node:%s" % _name
 	

--- a/project/ecs/test.gd
+++ b/project/ecs/test.gd
@@ -9,6 +9,7 @@ func _init():
 	test_entity()
 	test_component()
 	test_system()
+	test_system_node()
 	test_remove_component()
 	test_remove_entity()
 	test_remove_system()
@@ -51,6 +52,22 @@ func test_system():
 	_world.add_system("s2", ECSSystem.new())
 	_world.add_system("s2", ECSSystem.new())
 	_world.add_system("s3", ECSSystem.new())
+	print("")
+	
+func test_system_node():
+	print("begin ECSSystemNode test")
+	var system_node = ECSSystemNode.new()
+	_world.add_system("s_node", system_node)
+	printt("system list:", _world.get_system_keys())
+	system_node.get_remote_sender_id()
+	system_node.get_rpc_unique_id()
+	system_node.is_server()
+	system_node.is_peer_connected()
+	system_node.peer()
+	system_node.set_peer(null)
+	_world.remove_system("s_node")
+	printt("system list:", _world.get_system_keys())
+	print("end ECSSystemNode test")
 	print("")
 	
 func test_remove_component():


### PR DESCRIPTION
Create a dedicated system node class to remove the `Node` overhead from `ECSSystem` and make it extend `RefCounted` to align with `ECSEntity` and `ECSComponent`.

Also checking if the `Node` is inside the `SceneTree` before accessing `multiplayer`.