### PR TITLE
Create entity owner

### DIFF
--- a/project/ecs/entity.gd
+++ b/project/ecs/entity.gd
@@ -3,13 +3,15 @@ class_name ECSEntity
 
 var _id: int
 var _world: WeakRef
+var _owner: Object
 
 signal on_component_added(entity, component)
 signal on_component_removed(entity, component)
 
-func _init(id: int, world):
+func _init(id: int, world, owner: Object = null):
 	_id = id
 	_world = weakref(world)
+	_owner = owner
 	
 func destroy():
 	if _id != 0:
@@ -21,6 +23,9 @@ func id() -> int:
 	
 func world() -> ECSWorld:
 	return _world.get_ref()
+	
+func owner() -> Object:
+	return _owner
 	
 func valid() -> bool:
 	return _id >= 1 and world().has_entity(_id)

--- a/project/ecs/world.gd
+++ b/project/ecs/world.gd
@@ -26,9 +26,9 @@ func clear():
 	remove_all_commands()
 	remove_all_entities()
 	
-func create_entity() -> ECSEntity:
+func create_entity(owner: Object = null) -> ECSEntity:
 	_entity_id += 1
-	var e = ECSEntity.new(_entity_id, self)
+	var e = ECSEntity.new(_entity_id, self, owner)
 	_entity_pool[_entity_id] = e
 	_entity_component_dict[_entity_id] = {}
 	if debug_print:


### PR DESCRIPTION
Create entity owner in case the system needs to apply the component processed data to the Object/Node that owns the entity.

Example:

```gdscript
# Player.gd
extends CharacterBody3D

var entity := world.create_entity(self)

# System.gd
for c in view("my_component") as Array[my_component]:
	# ... Process component velocity data
	
	var owner := c.entity().owner() as CharacterBody3D
	if owner:
		owner.set_velocity(c.velocity)
		owner.set_up_direction(Vector3.UP)
		owner.move_and_slide()
```